### PR TITLE
Add favicon for browser tab icon

### DIFF
--- a/awards.html
+++ b/awards.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dr. C. Julio César Madera Quintana</title>
+    <link rel="icon" type="image/jpeg" href="images/profile.jpg">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dr. C. Julio César Madera Quintana</title>
+    <link rel="icon" type="image/jpeg" href="images/profile.jpg">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/postgraduate-courses.html
+++ b/postgraduate-courses.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dr. C. Julio César Madera Quintana</title>
+    <link rel="icon" type="image/jpeg" href="images/profile.jpg">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/publications.html
+++ b/publications.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dr. C. Julio César Madera Quintana</title>
+    <link rel="icon" type="image/jpeg" href="images/profile.jpg">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/responsibilities.html
+++ b/responsibilities.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dr. C. Julio César Madera Quintana</title>
+    <link rel="icon" type="image/jpeg" href="images/profile.jpg">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add `images/profile.jpg` as favicon for all HTML pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686ab3887a6c832a91317cc19a13b1d7